### PR TITLE
Add proxy support using npm config options proxy and https-proxy

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -31,7 +31,7 @@ execFile(chromium.path, ['https://google.com'], err => {
 ```
 
 ### Proxy Configuration
-When downloading the chromium binary **node-chromium** will use `npm`s configured proxy to establish HTTP(S) connections. The proxy used by `npm` can be configured using 
+When downloading the chromium binary **node-chromium** will use the proxy configured for `npm` to establish HTTP(S) connections. The proxy used by `npm` can be configured using 
 ```
 npm config set proxy http://<username>:<password>@<the.proxy.hostname>:<port>
 npm config set https-proxy http://<username>:<password>@<the.proxy.hostname>:<port

--- a/README.MD
+++ b/README.MD
@@ -30,6 +30,13 @@ execFile(chromium.path, ['https://google.com'], err => {
 });
 ```
 
+### Proxy Configuration
+When downloading the chromium binary **node-chromium** will use `npm`s configured proxy to establish HTTP(S) connections. The proxy used by `npm` can be configured using 
+```
+npm config set proxy http://<username>:<password>@<the.proxy.hostname>:<port>
+npm config set https-proxy http://<username>:<password>@<the.proxy.hostname>:<port
+```
+
 ## Selenium WebDriver Headless (without UI) tests
 It's extremely easy to use **node-chromium** with **selenium-webdriver** to perform e2e tests without spawning browser UI.
 First, install all dependencies
@@ -75,6 +82,7 @@ async function takeScreenshot(driver, name) {
 
 start();
 ```
+## 
 
 ## License
 MIT

--- a/install.js
+++ b/install.js
@@ -33,7 +33,7 @@ async function downloadChromiumRevision(revision) {
 
 function _downloadFile(url, destPath) {
     return new Promise((resolve, reject) => {
-        got.stream(url)
+        got.stream(url, utils.getRequestOptions(url))
             .on('error', error => {
                 console.error('An error occurred while trying to download file', error.message);
                 reject(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chromium",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,18 +16,18 @@
       "integrity": "sha512-oWqTnIGXW3k72UFidXzW0ONlO7hnO9x02S/QReJ7NBGeiBH9cUHY9+EfV6C8PXC6YJH++WrliEq03wMSJGNZFg==",
       "dev": true,
       "requires": {
-        "babel-plugin-check-es2015-constants": "^6.8.0",
-        "babel-plugin-syntax-trailing-function-commas": "^6.20.0",
-        "babel-plugin-transform-async-to-generator": "^6.16.0",
-        "babel-plugin-transform-es2015-destructuring": "^6.19.0",
-        "babel-plugin-transform-es2015-function-name": "^6.9.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
-        "babel-plugin-transform-es2015-parameters": "^6.21.0",
-        "babel-plugin-transform-es2015-spread": "^6.8.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.8.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.11.0",
-        "babel-plugin-transform-exponentiation-operator": "^6.8.0",
-        "package-hash": "^1.2.0"
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "package-hash": "1.2.0"
       },
       "dependencies": {
         "md5-hex": {
@@ -36,7 +36,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "md5-o-matic": "0.1.1"
           }
         },
         "package-hash": {
@@ -45,7 +45,7 @@
           "integrity": "sha1-AD5WzVe3NqbtYRTMK4FUJnJ3DkQ=",
           "dev": true,
           "requires": {
-            "md5-hex": "^1.3.0"
+            "md5-hex": "1.3.0"
           }
         }
       }
@@ -56,8 +56,8 @@
       "integrity": "sha1-ze0RlqjY2TgaUJJAq5LpGl7Aafc=",
       "dev": true,
       "requires": {
-        "@ava/babel-plugin-throws-helper": "^2.0.0",
-        "babel-plugin-espower": "^2.3.2"
+        "@ava/babel-plugin-throws-helper": "2.0.0",
+        "babel-plugin-espower": "2.3.2"
       }
     },
     "@ava/write-file-atomic": {
@@ -66,9 +66,9 @@
       "integrity": "sha512-BTNB3nGbEfJT+69wuqXFr/bQH7Vr7ihx2xGOMNqPgDGhwspoZhiWumDDZNjBy7AScmqS5CELIOGtPVXESyrnDA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
       }
     },
     "@concordance/react": {
@@ -77,7 +77,7 @@
       "integrity": "sha512-htrsRaQX8Iixlsek8zQU7tE8wcsTQJ5UhZkSPEA8slCDAisKpC/2VgU/ucPn32M5/LjGGXRaUEKvEw1Wiuu4zQ==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1"
+        "arrify": "1.0.1"
       }
     },
     "acorn": {
@@ -92,7 +92,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "^3.0.4"
+        "acorn": "3.3.0"
       },
       "dependencies": {
         "acorn": {
@@ -109,8 +109,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
       }
     },
     "ajv-keywords": {
@@ -125,7 +125,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       }
     },
     "ansi-escapes": {
@@ -146,7 +146,7 @@
       "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.0"
       }
     },
     "anymatch": {
@@ -155,8 +155,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "^2.1.5",
-        "normalize-path": "^2.0.0"
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
       }
     },
     "argparse": {
@@ -165,7 +165,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -174,7 +174,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.0.1"
+        "arr-flatten": "1.1.0"
       }
     },
     "arr-exclude": {
@@ -207,7 +207,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.1"
+        "array-uniq": "1.0.3"
       }
     },
     "array-uniq": {
@@ -246,86 +246,86 @@
       "integrity": "sha512-dYxvVDL9CeIcgaQ/FojaBVaL/rnIsXdgPVliDOMe1O5nSsIZEsPYDIzmZ1KnO/cuxeQx1PQbtW6qziiEwQZusg==",
       "dev": true,
       "requires": {
-        "@ava/babel-preset-stage-4": "^1.1.0",
-        "@ava/babel-preset-transform-test-files": "^3.0.0",
-        "@ava/write-file-atomic": "^2.2.0",
-        "@concordance/react": "^1.0.0",
-        "ansi-escapes": "^2.0.0",
-        "ansi-styles": "^3.1.0",
-        "arr-flatten": "^1.0.1",
-        "array-union": "^1.0.1",
-        "array-uniq": "^1.0.2",
-        "arrify": "^1.0.0",
-        "auto-bind": "^1.1.0",
-        "ava-init": "^0.2.0",
-        "babel-core": "^6.17.0",
-        "bluebird": "^3.0.0",
-        "caching-transform": "^1.0.0",
-        "chalk": "^2.0.1",
-        "chokidar": "^1.4.2",
-        "clean-stack": "^1.1.1",
-        "clean-yaml-object": "^0.1.0",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^1.0.0",
-        "cli-truncate": "^1.0.0",
-        "co-with-promise": "^4.6.0",
-        "code-excerpt": "^2.1.0",
-        "common-path-prefix": "^1.0.0",
-        "concordance": "^3.0.0",
-        "convert-source-map": "^1.2.0",
-        "core-assert": "^0.2.0",
-        "currently-unhandled": "^0.4.1",
-        "debug": "^2.2.0",
-        "dot-prop": "^4.1.0",
-        "empower-core": "^0.6.1",
-        "equal-length": "^1.0.0",
-        "figures": "^2.0.0",
-        "find-cache-dir": "^1.0.0",
-        "fn-name": "^2.0.0",
-        "get-port": "^3.0.0",
-        "globby": "^6.0.0",
-        "has-flag": "^2.0.0",
-        "hullabaloo-config-manager": "^1.1.0",
-        "ignore-by-default": "^1.0.0",
-        "import-local": "^0.1.1",
-        "indent-string": "^3.0.0",
-        "is-ci": "^1.0.7",
-        "is-generator-fn": "^1.0.0",
-        "is-obj": "^1.0.0",
-        "is-observable": "^0.2.0",
-        "is-promise": "^2.1.0",
-        "js-yaml": "^3.8.2",
-        "last-line-stream": "^1.0.0",
-        "lodash.clonedeepwith": "^4.5.0",
-        "lodash.debounce": "^4.0.3",
-        "lodash.difference": "^4.3.0",
-        "lodash.flatten": "^4.2.0",
-        "loud-rejection": "^1.2.0",
-        "make-dir": "^1.0.0",
-        "matcher": "^1.0.0",
-        "md5-hex": "^2.0.0",
-        "meow": "^3.7.0",
-        "ms": "^2.0.0",
-        "multimatch": "^2.1.0",
-        "observable-to-promise": "^0.5.0",
-        "option-chain": "^1.0.0",
-        "package-hash": "^2.0.0",
-        "pkg-conf": "^2.0.0",
-        "plur": "^2.0.0",
-        "pretty-ms": "^2.0.0",
-        "require-precompiled": "^0.1.0",
-        "resolve-cwd": "^2.0.0",
-        "safe-buffer": "^5.1.1",
-        "slash": "^1.0.0",
-        "source-map-support": "^0.4.0",
-        "stack-utils": "^1.0.0",
-        "strip-ansi": "^4.0.0",
-        "strip-bom-buf": "^1.0.0",
-        "supports-color": "^4.0.0",
-        "time-require": "^0.1.2",
-        "trim-off-newlines": "^1.0.1",
-        "unique-temp-dir": "^1.0.0",
-        "update-notifier": "^2.1.0"
+        "@ava/babel-preset-stage-4": "1.1.0",
+        "@ava/babel-preset-transform-test-files": "3.0.0",
+        "@ava/write-file-atomic": "2.2.0",
+        "@concordance/react": "1.0.0",
+        "ansi-escapes": "2.0.0",
+        "ansi-styles": "3.2.0",
+        "arr-flatten": "1.1.0",
+        "array-union": "1.0.2",
+        "array-uniq": "1.0.3",
+        "arrify": "1.0.1",
+        "auto-bind": "1.1.0",
+        "ava-init": "0.2.1",
+        "babel-core": "6.26.0",
+        "bluebird": "3.5.1",
+        "caching-transform": "1.0.1",
+        "chalk": "2.2.0",
+        "chokidar": "1.7.0",
+        "clean-stack": "1.3.0",
+        "clean-yaml-object": "0.1.0",
+        "cli-cursor": "2.1.0",
+        "cli-spinners": "1.1.0",
+        "cli-truncate": "1.1.0",
+        "co-with-promise": "4.6.0",
+        "code-excerpt": "2.1.0",
+        "common-path-prefix": "1.0.0",
+        "concordance": "3.0.0",
+        "convert-source-map": "1.5.0",
+        "core-assert": "0.2.1",
+        "currently-unhandled": "0.4.1",
+        "debug": "2.6.9",
+        "dot-prop": "4.2.0",
+        "empower-core": "0.6.2",
+        "equal-length": "1.0.1",
+        "figures": "2.0.0",
+        "find-cache-dir": "1.0.0",
+        "fn-name": "2.0.1",
+        "get-port": "3.2.0",
+        "globby": "6.1.0",
+        "has-flag": "2.0.0",
+        "hullabaloo-config-manager": "1.1.1",
+        "ignore-by-default": "1.0.1",
+        "import-local": "0.1.1",
+        "indent-string": "3.2.0",
+        "is-ci": "1.0.10",
+        "is-generator-fn": "1.0.0",
+        "is-obj": "1.0.1",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "js-yaml": "3.10.0",
+        "last-line-stream": "1.0.0",
+        "lodash.clonedeepwith": "4.5.0",
+        "lodash.debounce": "4.0.8",
+        "lodash.difference": "4.5.0",
+        "lodash.flatten": "4.4.0",
+        "loud-rejection": "1.6.0",
+        "make-dir": "1.0.0",
+        "matcher": "1.0.0",
+        "md5-hex": "2.0.0",
+        "meow": "3.7.0",
+        "ms": "2.0.0",
+        "multimatch": "2.1.0",
+        "observable-to-promise": "0.5.0",
+        "option-chain": "1.0.0",
+        "package-hash": "2.0.0",
+        "pkg-conf": "2.0.0",
+        "plur": "2.1.2",
+        "pretty-ms": "2.1.0",
+        "require-precompiled": "0.1.0",
+        "resolve-cwd": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "slash": "1.0.0",
+        "source-map-support": "0.4.18",
+        "stack-utils": "1.0.1",
+        "strip-ansi": "4.0.0",
+        "strip-bom-buf": "1.0.0",
+        "supports-color": "4.5.0",
+        "time-require": "0.1.2",
+        "trim-off-newlines": "1.0.1",
+        "unique-temp-dir": "1.0.0",
+        "update-notifier": "2.3.0"
       },
       "dependencies": {
         "debug": {
@@ -351,11 +351,11 @@
       "integrity": "sha512-lXwK5LM+2g1euDRqW1mcSX/tqzY1QU7EjKpqayFPPtNRmbSYZ8RzPO5tqluTToijmtjp2M+pNpVdbcHssC4glg==",
       "dev": true,
       "requires": {
-        "arr-exclude": "^1.0.0",
-        "execa": "^0.7.0",
-        "has-yarn": "^1.0.0",
-        "read-pkg-up": "^2.0.0",
-        "write-pkg": "^3.1.0"
+        "arr-exclude": "1.0.0",
+        "execa": "0.7.0",
+        "has-yarn": "1.0.0",
+        "read-pkg-up": "2.0.0",
+        "write-pkg": "3.1.0"
       }
     },
     "babel-code-frame": {
@@ -364,9 +364,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       },
       "dependencies": {
         "ansi-styles": {
@@ -381,11 +381,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "strip-ansi": {
@@ -394,7 +394,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -411,25 +411,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-generator": "^6.26.0",
-        "babel-helpers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-register": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "convert-source-map": "^1.5.0",
-        "debug": "^2.6.8",
-        "json5": "^0.5.1",
-        "lodash": "^4.17.4",
-        "minimatch": "^3.0.4",
-        "path-is-absolute": "^1.0.1",
-        "private": "^0.1.7",
-        "slash": "^1.0.0",
-        "source-map": "^0.5.6"
+        "babel-code-frame": "6.26.0",
+        "babel-generator": "6.26.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "convert-source-map": "1.5.0",
+        "debug": "2.6.9",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.8",
+        "slash": "1.0.0",
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "debug": {
@@ -455,14 +455,14 @@
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.6",
-        "trim-right": "^1.0.1"
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
       },
       "dependencies": {
         "jsesc": {
@@ -479,9 +479,9 @@
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
       "dev": true,
       "requires": {
-        "babel-helper-explode-assignable-expression": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-call-delegate": {
@@ -490,10 +490,10 @@
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
       "dev": true,
       "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -502,9 +502,9 @@
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -513,11 +513,11 @@
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
       "dev": true,
       "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-get-function-arity": {
@@ -526,8 +526,8 @@
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-hoist-variables": {
@@ -536,8 +536,8 @@
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-regex": {
@@ -546,9 +546,9 @@
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "lodash": "4.17.4"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -557,11 +557,11 @@
       "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
@@ -570,8 +570,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
       }
     },
     "babel-messages": {
@@ -580,7 +580,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -589,7 +589,7 @@
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-espower": {
@@ -598,13 +598,13 @@
       "integrity": "sha1-VRa4/NsmyfDh2BYHSfbkxl5xJx4=",
       "dev": true,
       "requires": {
-        "babel-generator": "^6.1.0",
-        "babylon": "^6.1.0",
-        "call-matcher": "^1.0.0",
-        "core-js": "^2.0.0",
-        "espower-location-detector": "^1.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.1.1"
+        "babel-generator": "6.26.0",
+        "babylon": "6.18.0",
+        "call-matcher": "1.0.1",
+        "core-js": "2.5.1",
+        "espower-location-detector": "1.0.0",
+        "espurify": "1.7.0",
+        "estraverse": "4.2.0"
       }
     },
     "babel-plugin-syntax-async-functions": {
@@ -631,9 +631,9 @@
       "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
       "dev": true,
       "requires": {
-        "babel-helper-remap-async-to-generator": "^6.24.1",
-        "babel-plugin-syntax-async-functions": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-remap-async-to-generator": "6.24.1",
+        "babel-plugin-syntax-async-functions": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-destructuring": {
@@ -642,7 +642,7 @@
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-function-name": {
@@ -651,9 +651,9 @@
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
       "dev": true,
       "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
@@ -662,10 +662,10 @@
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
       "dev": true,
       "requires": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-parameters": {
@@ -674,12 +674,12 @@
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
       "dev": true,
       "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-spread": {
@@ -688,7 +688,7 @@
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
@@ -697,9 +697,9 @@
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
@@ -708,9 +708,9 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true,
       "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
+        "babel-helper-regex": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "regexpu-core": "2.0.0"
       }
     },
     "babel-plugin-transform-exponentiation-operator": {
@@ -719,9 +719,9 @@
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
       "dev": true,
       "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-        "babel-runtime": "^6.22.0"
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-plugin-transform-strict-mode": {
@@ -730,8 +730,8 @@
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-register": {
@@ -740,13 +740,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "^6.26.0",
-        "babel-runtime": "^6.26.0",
-        "core-js": "^2.5.0",
-        "home-or-tmp": "^2.0.0",
-        "lodash": "^4.17.4",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.4.15"
+        "babel-core": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.18"
       },
       "dependencies": {
         "mkdirp": {
@@ -766,8 +766,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.11.0"
       }
     },
     "babel-template": {
@@ -776,11 +776,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "lodash": "4.17.4"
       }
     },
     "babel-traverse": {
@@ -789,15 +789,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
       },
       "dependencies": {
         "debug": {
@@ -823,10 +823,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
@@ -859,13 +859,13 @@
       "integrity": "sha1-Px1AMsMP/qnUsCwyLq8up0HcvOU=",
       "dev": true,
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^1.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.2.0",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -882,7 +882,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -892,9 +892,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "^1.8.1",
-        "preserve": "^0.2.0",
-        "repeat-element": "^1.1.2"
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
       }
     },
     "buf-compare": {
@@ -920,9 +920,9 @@
       "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
       "dev": true,
       "requires": {
-        "md5-hex": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "write-file-atomic": "^1.1.4"
+        "md5-hex": "1.3.0",
+        "mkdirp": "0.5.1",
+        "write-file-atomic": "1.3.4"
       },
       "dependencies": {
         "md5-hex": {
@@ -931,7 +931,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "md5-o-matic": "0.1.1"
           }
         },
         "mkdirp": {
@@ -949,9 +949,9 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         }
       }
@@ -962,10 +962,10 @@
       "integrity": "sha1-UTTQd5hPcSpU2tPL9i3ijc5BbKg=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0",
-        "deep-equal": "^1.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.0.0"
+        "core-js": "2.5.1",
+        "deep-equal": "1.0.1",
+        "espurify": "1.7.0",
+        "estraverse": "4.2.0"
       }
     },
     "call-signature": {
@@ -980,7 +980,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "^0.2.0"
+        "callsites": "0.2.0"
       }
     },
     "callsites": {
@@ -1001,8 +1001,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
       }
     },
     "capture-stack-trace": {
@@ -1017,9 +1017,9 @@
       "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.1.0",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^4.0.0"
+        "ansi-styles": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "4.5.0"
       }
     },
     "chokidar": {
@@ -1028,15 +1028,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "^1.3.0",
-        "async-each": "^1.0.0",
-        "fsevents": "^1.0.0",
-        "glob-parent": "^2.0.0",
-        "inherits": "^2.0.1",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^2.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.0.0"
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
       }
     },
     "ci-info": {
@@ -1075,7 +1075,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "2.0.0"
       }
     },
     "cli-spinners": {
@@ -1090,8 +1090,8 @@
       "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
       "dev": true,
       "requires": {
-        "slice-ansi": "^1.0.0",
-        "string-width": "^2.0.0"
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
       }
     },
     "cli-width": {
@@ -1112,7 +1112,7 @@
       "integrity": "sha1-QT59tvWJOmC5Qs9JLEvsk9tBWrc=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "^1.0.0"
+        "pinkie-promise": "1.0.0"
       }
     },
     "code-excerpt": {
@@ -1121,7 +1121,7 @@
       "integrity": "sha1-XcwIHoj0p+O1VOnjXX7yMtR/gUc=",
       "dev": true,
       "requires": {
-        "convert-to-spaces": "^1.0.1"
+        "convert-to-spaces": "1.0.2"
       }
     },
     "code-point-at": {
@@ -1136,7 +1136,7 @@
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "dev": true,
       "requires": {
-        "color-name": "^1.1.1"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
@@ -1169,9 +1169,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
       }
     },
     "concordance": {
@@ -1180,17 +1180,17 @@
       "integrity": "sha512-CZBzJ3/l5QJjlZM20WY7+5GP5pMTw+1UEbThcpMw8/rojsi5sBCiD8ZbBLtD+jYpRGAkwuKuqk108c154V9eyQ==",
       "dev": true,
       "requires": {
-        "date-time": "^2.1.0",
-        "esutils": "^2.0.2",
-        "fast-diff": "^1.1.1",
-        "function-name-support": "^0.2.0",
-        "js-string-escape": "^1.0.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.flattendeep": "^4.4.0",
-        "lodash.merge": "^4.6.0",
-        "md5-hex": "^2.0.0",
-        "semver": "^5.3.0",
-        "well-known-symbols": "^1.0.0"
+        "date-time": "2.1.0",
+        "esutils": "2.0.2",
+        "fast-diff": "1.1.2",
+        "function-name-support": "0.2.0",
+        "js-string-escape": "1.0.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.flattendeep": "4.4.0",
+        "lodash.merge": "4.6.0",
+        "md5-hex": "2.0.0",
+        "semver": "5.4.1",
+        "well-known-symbols": "1.0.0"
       }
     },
     "configstore": {
@@ -1199,12 +1199,12 @@
       "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.0.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.3.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "contains-path": {
@@ -1231,8 +1231,8 @@
       "integrity": "sha1-+F4s+b/tKPdzzIs/pcW2m9wC/j8=",
       "dev": true,
       "requires": {
-        "buf-compare": "^1.0.0",
-        "is-error": "^2.2.0"
+        "buf-compare": "1.0.1",
+        "is-error": "2.2.1"
       }
     },
     "core-js": {
@@ -1252,7 +1252,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.0"
       }
     },
     "cross-spawn": {
@@ -1261,9 +1261,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.3.0"
       }
     },
     "crypto-random-string": {
@@ -1278,7 +1278,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "^1.0.1"
+        "array-find-index": "1.0.2"
       }
     },
     "d": {
@@ -1287,7 +1287,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "0.10.35"
       }
     },
     "date-time": {
@@ -1296,7 +1296,7 @@
       "integrity": "sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==",
       "dev": true,
       "requires": {
-        "time-zone": "^1.0.0"
+        "time-zone": "1.0.0"
       }
     },
     "debug": {
@@ -1304,7 +1304,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
       "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.1"
       }
     },
     "decamelize": {
@@ -1318,7 +1318,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "deep-assign": {
@@ -1327,7 +1327,7 @@
       "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "deep-equal": {
@@ -1354,7 +1354,7 @@
       "integrity": "sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=",
       "dev": true,
       "requires": {
-        "core-assert": "^0.2.0"
+        "core-assert": "0.2.1"
       }
     },
     "del": {
@@ -1363,13 +1363,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "globby": {
@@ -1378,12 +1378,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pinkie": {
@@ -1398,7 +1398,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         }
       }
@@ -1409,7 +1409,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "^2.0.0"
+        "repeating": "2.0.1"
       }
     },
     "doctrine": {
@@ -1418,8 +1418,8 @@
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
-        "isarray": "^1.0.0"
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
       }
     },
     "dot-prop": {
@@ -1428,7 +1428,7 @@
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "duplexer3": {
@@ -1443,7 +1443,7 @@
       "dev": true,
       "requires": {
         "call-signature": "0.0.2",
-        "core-js": "^2.0.0"
+        "core-js": "2.5.1"
       }
     },
     "enhance-visitors": {
@@ -1452,7 +1452,7 @@
       "integrity": "sha1-qpRdBdpGVnKh69OP7i7T2oUY6Vo=",
       "dev": true,
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "4.17.4"
       }
     },
     "equal-length": {
@@ -1467,7 +1467,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es5-ext": {
@@ -1476,8 +1476,8 @@
       "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
       "dev": true,
       "requires": {
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "~3.1.1"
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-error": {
@@ -1492,9 +1492,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-symbol": "3.1.1"
       }
     },
     "es6-map": {
@@ -1503,12 +1503,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
       }
     },
     "es6-set": {
@@ -1517,11 +1517,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
+        "event-emitter": "0.3.5"
       }
     },
     "es6-symbol": {
@@ -1530,8 +1530,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
       }
     },
     "es6-weak-map": {
@@ -1540,10 +1540,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
-        "es6-symbol": "^3.1.1"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1558,10 +1558,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "^0.1.3",
-        "es6-weak-map": "^2.0.1",
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
       }
     },
     "eslint": {
@@ -1570,41 +1570,41 @@
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.16.0",
-        "chalk": "^1.1.3",
-        "concat-stream": "^1.5.2",
-        "debug": "^2.1.1",
-        "doctrine": "^2.0.0",
-        "escope": "^3.6.0",
-        "espree": "^3.4.0",
-        "esquery": "^1.0.0",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "file-entry-cache": "^2.0.0",
-        "glob": "^7.0.3",
-        "globals": "^9.14.0",
-        "ignore": "^3.2.0",
-        "imurmurhash": "^0.1.4",
-        "inquirer": "^0.12.0",
-        "is-my-json-valid": "^2.10.0",
-        "is-resolvable": "^1.0.0",
-        "js-yaml": "^3.5.1",
-        "json-stable-stringify": "^1.0.0",
-        "levn": "^0.3.0",
-        "lodash": "^4.0.0",
-        "mkdirp": "^0.5.0",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.8.2",
-        "path-is-inside": "^1.0.1",
-        "pluralize": "^1.2.1",
-        "progress": "^1.1.8",
-        "require-uncached": "^1.0.2",
-        "shelljs": "^0.7.5",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "~2.0.1",
-        "table": "^3.7.8",
-        "text-table": "~0.2.0",
-        "user-home": "^2.0.0"
+        "babel-code-frame": "6.26.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.5.1",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.5",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.1",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.0",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1619,11 +1619,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "debug": {
@@ -1647,7 +1647,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -1670,11 +1670,11 @@
       "integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^2.0.0",
-        "chalk": "^2.1.0",
-        "log-symbols": "^2.0.0",
-        "plur": "^2.1.2",
-        "string-width": "^2.0.0"
+        "ansi-escapes": "2.0.0",
+        "chalk": "2.2.0",
+        "log-symbols": "2.1.0",
+        "plur": "2.1.2",
+        "string-width": "2.1.1"
       }
     },
     "eslint-import-resolver-node": {
@@ -1683,8 +1683,8 @@
       "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "resolve": "^1.2.0"
+        "debug": "2.6.9",
+        "resolve": "1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -1710,8 +1710,8 @@
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.8",
-        "pkg-dir": "^1.0.0"
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1729,8 +1729,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "ms": {
@@ -1745,7 +1745,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "pinkie": {
@@ -1760,7 +1760,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "pkg-dir": {
@@ -1769,7 +1769,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0"
+            "find-up": "1.1.2"
           }
         }
       }
@@ -1780,14 +1780,14 @@
       "integrity": "sha512-a4QDn9dyiFuwtQSQMDLDyklpf3/uQ7eT3+fVs0U/7cFPQF8IvhK3HpFCTd5iDGC7hljMDU9PFIUP+3Se4LV7fg==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.1",
-        "deep-strict-equal": "^0.2.0",
-        "enhance-visitors": "^1.0.0",
-        "espree": "^3.1.3",
-        "espurify": "^1.5.0",
-        "import-modules": "^1.1.0",
-        "multimatch": "^2.1.0",
-        "pkg-up": "^2.0.0"
+        "arrify": "1.0.1",
+        "deep-strict-equal": "0.2.0",
+        "enhance-visitors": "1.0.0",
+        "espree": "3.5.1",
+        "espurify": "1.7.0",
+        "import-modules": "1.1.0",
+        "multimatch": "2.1.0",
+        "pkg-up": "2.0.0"
       }
     },
     "eslint-plugin-import": {
@@ -1796,16 +1796,16 @@
       "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.1.1",
-        "contains-path": "^0.1.0",
-        "debug": "^2.6.8",
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.1",
-        "eslint-module-utils": "^2.1.1",
-        "has": "^1.0.1",
-        "lodash.cond": "^4.3.0",
-        "minimatch": "^3.0.3",
-        "read-pkg-up": "^2.0.0"
+        "eslint-import-resolver-node": "0.3.1",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
       },
       "dependencies": {
         "debug": {
@@ -1823,8 +1823,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "^2.0.2",
-            "isarray": "^1.0.0"
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
           }
         },
         "ms": {
@@ -1841,10 +1841,10 @@
       "integrity": "sha1-OtmgDC3yO11/f2vpFVCYWkq3Aeo=",
       "dev": true,
       "requires": {
-        "is-get-set-prop": "^1.0.0",
-        "is-js-type": "^2.0.0",
-        "is-obj-prop": "^1.0.0",
-        "is-proto-prop": "^1.0.0"
+        "is-get-set-prop": "1.0.0",
+        "is-js-type": "2.0.0",
+        "is-obj-prop": "1.0.0",
+        "is-proto-prop": "1.0.0"
       }
     },
     "eslint-plugin-promise": {
@@ -1859,11 +1859,11 @@
       "integrity": "sha1-md/+n0dzsEvDk1an/r1k3XACdLw=",
       "dev": true,
       "requires": {
-        "import-modules": "^1.1.0",
-        "lodash.camelcase": "^4.1.1",
-        "lodash.kebabcase": "^4.0.1",
-        "lodash.snakecase": "^4.0.1",
-        "lodash.upperfirst": "^4.2.0"
+        "import-modules": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "lodash.kebabcase": "4.1.1",
+        "lodash.snakecase": "4.1.1",
+        "lodash.upperfirst": "4.3.1"
       }
     },
     "espower-location-detector": {
@@ -1872,10 +1872,10 @@
       "integrity": "sha1-oXt+zFnTDheeK+9z+0E3cEyzMbU=",
       "dev": true,
       "requires": {
-        "is-url": "^1.2.1",
-        "path-is-absolute": "^1.0.0",
-        "source-map": "^0.5.0",
-        "xtend": "^4.0.0"
+        "is-url": "1.2.2",
+        "path-is-absolute": "1.0.1",
+        "source-map": "0.5.7",
+        "xtend": "4.0.1"
       }
     },
     "espree": {
@@ -1884,8 +1884,8 @@
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
-        "acorn": "^5.1.1",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "5.1.2",
+        "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
@@ -1900,7 +1900,7 @@
       "integrity": "sha1-HFz2y8zDLm9jk4C9T5kfq5up0iY=",
       "dev": true,
       "requires": {
-        "core-js": "^2.0.0"
+        "core-js": "2.5.1"
       }
     },
     "esquery": {
@@ -1909,7 +1909,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "4.2.0"
       }
     },
     "esrecurse": {
@@ -1918,8 +1918,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0",
-        "object-assign": "^4.0.1"
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
       }
     },
     "estraverse": {
@@ -1940,8 +1940,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "1.0.0",
+        "es5-ext": "0.10.35"
       }
     },
     "execa": {
@@ -1950,13 +1950,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.2",
+        "strip-eof": "1.0.0"
       }
     },
     "exit-hook": {
@@ -1971,7 +1971,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "^0.1.0"
+        "is-posix-bracket": "0.1.1"
       }
     },
     "expand-range": {
@@ -1980,7 +1980,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "^2.1.0"
+        "fill-range": "2.2.3"
       }
     },
     "extglob": {
@@ -1989,7 +1989,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "extract-zip": {
@@ -2008,10 +2008,10 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "buffer-from": "1.1.1",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.3",
+            "typedarray": "0.0.6"
           }
         },
         "debug": {
@@ -2054,7 +2054,7 @@
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "figures": {
@@ -2063,7 +2063,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "file-entry-cache": {
@@ -2072,8 +2072,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "^1.2.1",
-        "object-assign": "^4.0.1"
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "filename-regex": {
@@ -2088,11 +2088,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "^2.1.0",
-        "isobject": "^2.0.0",
-        "randomatic": "^1.1.3",
-        "repeat-element": "^1.1.2",
-        "repeat-string": "^1.5.2"
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
       }
     },
     "find-cache-dir": {
@@ -2101,9 +2101,9 @@
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
       "dev": true,
       "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^1.0.0",
-        "pkg-dir": "^2.0.0"
+        "commondir": "1.0.1",
+        "make-dir": "1.0.0",
+        "pkg-dir": "2.0.0"
       }
     },
     "find-up": {
@@ -2112,7 +2112,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "flat-cache": {
@@ -2121,10 +2121,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "^0.3.1",
-        "del": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "write": "^0.2.1"
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
       }
     },
     "fn-name": {
@@ -2145,7 +2145,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.1"
+        "for-in": "1.0.2"
       }
     },
     "fs.realpath": {
@@ -2161,8 +2161,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
+        "nan": "2.11.1",
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -2188,8 +2188,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
@@ -2202,7 +2202,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -2266,7 +2266,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -2281,14 +2281,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -2297,12 +2297,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -2317,7 +2317,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -2326,7 +2326,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -2335,8 +2335,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -2355,7 +2355,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -2369,7 +2369,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -2382,8 +2382,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -2392,7 +2392,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
@@ -2415,9 +2415,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -2426,16 +2426,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -2444,8 +2444,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -2460,8 +2460,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -2470,10 +2470,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
@@ -2492,7 +2492,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -2513,8 +2513,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -2535,10 +2535,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2555,13 +2555,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -2570,7 +2570,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -2613,9 +2613,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -2624,7 +2624,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -2632,7 +2632,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -2647,13 +2647,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -2668,7 +2668,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -2707,7 +2707,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "get-port": {
@@ -2739,12 +2739,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-base": {
@@ -2753,8 +2753,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "glob-parent": {
@@ -2763,7 +2763,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "^2.0.0"
+        "is-glob": "2.0.1"
       }
     },
     "global-dirs": {
@@ -2772,7 +2772,7 @@
       "integrity": "sha1-ENNAOeDfBCcuJizyQiT3IJQ0308=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.4"
       }
     },
     "globals": {
@@ -2787,11 +2787,11 @@
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "array-union": "1.0.2",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pinkie": {
@@ -2806,7 +2806,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         }
       }
@@ -2816,20 +2816,20 @@
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
       "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
       "requires": {
-        "decompress-response": "^3.2.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "p-cancelable": "^0.3.0",
-        "p-timeout": "^1.1.1",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "url-parse-lax": "^1.0.0",
-        "url-to-options": "^1.0.1"
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "is-plain-obj": "1.1.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.0",
+        "p-cancelable": "0.3.0",
+        "p-timeout": "1.2.0",
+        "safe-buffer": "5.1.1",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "1.0.0",
+        "url-to-options": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -2844,7 +2844,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "^1.0.2"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -2853,7 +2853,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-color": {
@@ -2878,7 +2878,7 @@
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.0.tgz",
       "integrity": "sha512-R3OdOP9j6AH5hS1yXeu9wAS+iKSZQx/CC6aMdN6WiaqPlBoA2S+47MtoMsZgKr2m0eAJ+73WWGX0RaFFE5XWKA==",
       "requires": {
-        "has-symbol-support-x": "^1.4.0"
+        "has-symbol-support-x": "1.4.0"
       }
     },
     "has-yarn": {
@@ -2893,8 +2893,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.1"
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
       }
     },
     "hosted-git-info": {
@@ -2909,20 +2909,20 @@
       "integrity": "sha512-ztKnkZV0TmxnumCDHHgLGNiDnotu4EHCp9YMkznWuo4uTtCyJ+cu+RNcxUeXYKTllpvLFWnbfWry09yzszgg+A==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "es6-error": "^4.0.2",
-        "graceful-fs": "^4.1.11",
-        "indent-string": "^3.1.0",
-        "json5": "^0.5.1",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.clonedeepwith": "^4.5.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.merge": "^4.6.0",
-        "md5-hex": "^2.0.0",
-        "package-hash": "^2.0.0",
-        "pkg-dir": "^2.0.0",
-        "resolve-from": "^3.0.0",
-        "safe-buffer": "^5.0.1"
+        "dot-prop": "4.2.0",
+        "es6-error": "4.0.2",
+        "graceful-fs": "4.1.11",
+        "indent-string": "3.2.0",
+        "json5": "0.5.1",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.clonedeepwith": "4.5.0",
+        "lodash.isequal": "4.5.0",
+        "lodash.merge": "4.6.0",
+        "md5-hex": "2.0.0",
+        "package-hash": "2.0.0",
+        "pkg-dir": "2.0.0",
+        "resolve-from": "3.0.0",
+        "safe-buffer": "5.1.1"
       }
     },
     "ignore": {
@@ -2949,8 +2949,8 @@
       "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
       "dev": true,
       "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       }
     },
     "import-modules": {
@@ -2977,8 +2977,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -2998,19 +2998,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.1.0",
-        "ansi-regex": "^2.0.0",
-        "chalk": "^1.0.0",
-        "cli-cursor": "^1.0.1",
-        "cli-width": "^2.0.0",
-        "figures": "^1.3.5",
-        "lodash": "^4.3.0",
-        "readline2": "^1.0.1",
-        "run-async": "^0.1.0",
-        "rx-lite": "^3.1.2",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.0",
-        "through": "^2.3.6"
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -3031,11 +3031,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "cli-cursor": {
@@ -3044,7 +3044,7 @@
           "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
           "dev": true,
           "requires": {
-            "restore-cursor": "^1.0.1"
+            "restore-cursor": "1.0.1"
           }
         },
         "figures": {
@@ -3053,8 +3053,8 @@
           "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
           "dev": true,
           "requires": {
-            "escape-string-regexp": "^1.0.5",
-            "object-assign": "^4.1.0"
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
           }
         },
         "is-fullwidth-code-point": {
@@ -3063,7 +3063,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "onetime": {
@@ -3078,8 +3078,8 @@
           "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
           "dev": true,
           "requires": {
-            "exit-hook": "^1.0.0",
-            "onetime": "^1.0.0"
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
           }
         },
         "string-width": {
@@ -3088,9 +3088,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -3099,7 +3099,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -3122,7 +3122,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.3.1"
       }
     },
     "irregular-plurals": {
@@ -3143,7 +3143,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "1.10.0"
       }
     },
     "is-buffer": {
@@ -3158,7 +3158,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "^1.0.0"
+        "builtin-modules": "1.1.1"
       }
     },
     "is-ci": {
@@ -3167,7 +3167,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "1.1.1"
       }
     },
     "is-dotfile": {
@@ -3182,7 +3182,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "^2.0.0"
+        "is-primitive": "2.0.0"
       }
     },
     "is-error": {
@@ -3209,7 +3209,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-fullwidth-code-point": {
@@ -3230,8 +3230,8 @@
       "integrity": "sha1-JzGHfk14pqae3M5rudaLB3nnYxI=",
       "dev": true,
       "requires": {
-        "get-set-props": "^0.1.0",
-        "lowercase-keys": "^1.0.0"
+        "get-set-props": "0.1.0",
+        "lowercase-keys": "1.0.0"
       }
     },
     "is-glob": {
@@ -3240,7 +3240,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "^1.0.0"
+        "is-extglob": "1.0.0"
       }
     },
     "is-installed-globally": {
@@ -3249,8 +3249,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.0",
+        "is-path-inside": "1.0.0"
       }
     },
     "is-js-type": {
@@ -3259,7 +3259,7 @@
       "integrity": "sha1-c2FwBtZZtOtHKbunR9KHgt8PfiI=",
       "dev": true,
       "requires": {
-        "js-types": "^1.0.0"
+        "js-types": "1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -3268,10 +3268,10 @@
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.1.0",
-        "jsonpointer": "^4.0.0",
-        "xtend": "^4.0.0"
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
       }
     },
     "is-npm": {
@@ -3286,7 +3286,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       }
     },
     "is-obj": {
@@ -3301,8 +3301,8 @@
       "integrity": "sha1-s03nnEULjXxzqyzfZ9yHWtuF+A4=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^1.0.0",
-        "obj-props": "^1.0.0"
+        "lowercase-keys": "1.0.0",
+        "obj-props": "1.1.0"
       }
     },
     "is-object": {
@@ -3316,7 +3316,7 @@
       "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
       "dev": true,
       "requires": {
-        "symbol-observable": "^0.2.2"
+        "symbol-observable": "0.2.4"
       }
     },
     "is-path-cwd": {
@@ -3331,7 +3331,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "1.0.0"
       }
     },
     "is-path-inside": {
@@ -3340,7 +3340,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -3378,8 +3378,8 @@
       "integrity": "sha1-s5UflcCJkk+11PzaZUKrPoPisiA=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^1.0.0",
-        "proto-props": "^0.2.0"
+        "lowercase-keys": "1.0.0",
+        "proto-props": "0.2.1"
       }
     },
     "is-redirect": {
@@ -3394,7 +3394,7 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "^1.0.1"
+        "tryit": "1.0.3"
       }
     },
     "is-retry-allowed": {
@@ -3444,8 +3444,8 @@
       "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.0",
+        "is-object": "1.0.1"
       }
     },
     "js-string-escape": {
@@ -3472,8 +3472,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
       }
     },
     "jsesc": {
@@ -3488,7 +3488,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "~0.0.0"
+        "jsonify": "0.0.0"
       }
     },
     "json5": {
@@ -3515,7 +3515,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "^1.1.5"
+        "is-buffer": "1.1.5"
       }
     },
     "last-line-stream": {
@@ -3524,7 +3524,7 @@
       "integrity": "sha1-0bZNafhv8kry0EiDos7uFFIKVgA=",
       "dev": true,
       "requires": {
-        "through2": "^2.0.0"
+        "through2": "2.0.3"
       }
     },
     "latest-version": {
@@ -3533,7 +3533,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "levn": {
@@ -3542,8 +3542,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "load-json-file": {
@@ -3552,10 +3552,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "strip-bom": "^3.0.0"
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
       }
     },
     "locate-path": {
@@ -3564,8 +3564,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lodash": {
@@ -3658,7 +3658,7 @@
       "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.0.1"
+        "chalk": "2.2.0"
       }
     },
     "loose-envify": {
@@ -3667,7 +3667,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0"
+        "js-tokens": "3.0.2"
       }
     },
     "loud-rejection": {
@@ -3676,8 +3676,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
       }
     },
     "lowercase-keys": {
@@ -3691,8 +3691,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       }
     },
     "make-dir": {
@@ -3701,7 +3701,7 @@
       "integrity": "sha1-l6ARdR6R3YfPre9Ygy67BJNt6Xg=",
       "dev": true,
       "requires": {
-        "pify": "^2.3.0"
+        "pify": "2.3.0"
       }
     },
     "map-obj": {
@@ -3716,7 +3716,7 @@
       "integrity": "sha1-qvDEgW62m5IJRnQXViXzRmsOPhk=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.4"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "md5-hex": {
@@ -3725,7 +3725,7 @@
       "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
       "dev": true,
       "requires": {
-        "md5-o-matic": "^0.1.1"
+        "md5-o-matic": "0.1.1"
       }
     },
     "md5-o-matic": {
@@ -3740,16 +3740,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -3758,8 +3758,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "load-json-file": {
@@ -3768,11 +3768,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "minimist": {
@@ -3787,7 +3787,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-type": {
@@ -3796,9 +3796,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pinkie": {
@@ -3813,7 +3813,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "read-pkg": {
@@ -3822,9 +3822,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -3833,8 +3833,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "strip-bom": {
@@ -3843,7 +3843,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         }
       }
@@ -3854,19 +3854,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "^2.0.0",
-        "array-unique": "^0.2.1",
-        "braces": "^1.8.2",
-        "expand-brackets": "^0.1.4",
-        "extglob": "^0.3.1",
-        "filename-regex": "^2.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.1",
-        "kind-of": "^3.0.2",
-        "normalize-path": "^2.0.1",
-        "object.omit": "^2.0.0",
-        "parse-glob": "^3.0.4",
-        "regex-cache": "^0.4.2"
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
       }
     },
     "mimic-fn": {
@@ -3886,7 +3886,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -3914,10 +3914,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "^1.0.0",
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "minimatch": "^3.0.0"
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
       }
     },
     "mute-stream": {
@@ -3945,10 +3945,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
       }
     },
     "normalize-path": {
@@ -3957,7 +3957,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "^1.0.1"
+        "remove-trailing-separator": "1.1.0"
       }
     },
     "npm-run-path": {
@@ -3966,7 +3966,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -3993,8 +3993,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "^0.1.4",
-        "is-extendable": "^0.1.1"
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
       }
     },
     "observable-to-promise": {
@@ -4003,8 +4003,8 @@
       "integrity": "sha1-yCjw8NxH6fhq+KSXfF1VB2znqR8=",
       "dev": true,
       "requires": {
-        "is-observable": "^0.2.0",
-        "symbol-observable": "^1.0.4"
+        "is-observable": "0.2.0",
+        "symbol-observable": "1.0.4"
       },
       "dependencies": {
         "symbol-observable": {
@@ -4021,7 +4021,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -4030,7 +4030,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "1.1.0"
       }
     },
     "option-chain": {
@@ -4045,12 +4045,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "os-homedir": {
@@ -4086,7 +4086,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.1.0"
       }
     },
     "p-timeout": {
@@ -4094,7 +4094,7 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.0.tgz",
       "integrity": "sha1-mCD5lDTFgXhotPNICe5SkWYNW2w=",
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "package-hash": {
@@ -4103,10 +4103,10 @@
       "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "lodash.flattendeep": "^4.4.0",
-        "md5-hex": "^2.0.0",
-        "release-zalgo": "^1.0.0"
+        "graceful-fs": "4.1.11",
+        "lodash.flattendeep": "4.4.0",
+        "md5-hex": "2.0.0",
+        "release-zalgo": "1.0.0"
       }
     },
     "package-json": {
@@ -4115,10 +4115,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.3.1",
+        "registry-url": "3.1.0",
+        "semver": "5.4.1"
       },
       "dependencies": {
         "got": {
@@ -4127,17 +4127,17 @@
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.0",
+            "safe-buffer": "5.1.1",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         }
       }
@@ -4148,10 +4148,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
       }
     },
     "parse-json": {
@@ -4160,7 +4160,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.1"
       }
     },
     "parse-ms": {
@@ -4205,7 +4205,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "^2.0.0"
+        "pify": "2.3.0"
       }
     },
     "pend": {
@@ -4231,7 +4231,7 @@
       "integrity": "sha1-0dpn9UglY7t89X8oauKCLs+/NnA=",
       "dev": true,
       "requires": {
-        "pinkie": "^1.0.0"
+        "pinkie": "1.0.0"
       }
     },
     "pkg-conf": {
@@ -4240,8 +4240,8 @@
       "integrity": "sha1-BxyHZQQDvM+5xif1h1G/5HwGcnk=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "load-json-file": "^2.0.0"
+        "find-up": "2.1.0",
+        "load-json-file": "2.0.0"
       }
     },
     "pkg-dir": {
@@ -4250,7 +4250,7 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       }
     },
     "pkg-up": {
@@ -4259,7 +4259,7 @@
       "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "2.1.0"
       }
     },
     "plur": {
@@ -4268,7 +4268,7 @@
       "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "1.4.0"
       }
     },
     "pluralize": {
@@ -4300,9 +4300,9 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.1",
-        "parse-ms": "^1.0.0",
-        "plur": "^1.0.0"
+        "is-finite": "1.0.2",
+        "parse-ms": "1.0.1",
+        "plur": "1.0.0"
       },
       "dependencies": {
         "plur": {
@@ -4348,8 +4348,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -4358,7 +4358,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4367,7 +4367,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.5"
               }
             }
           }
@@ -4378,7 +4378,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.5"
           }
         }
       }
@@ -4389,10 +4389,10 @@
       "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "dev": true,
       "requires": {
-        "deep-extend": "~0.4.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -4409,9 +4409,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^2.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^2.0.0"
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
       }
     },
     "read-pkg-up": {
@@ -4420,8 +4420,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^2.0.0"
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
       }
     },
     "readable-stream": {
@@ -4429,13 +4429,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -4444,10 +4444,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "minimatch": "^3.0.2",
-        "readable-stream": "^2.0.2",
-        "set-immediate-shim": "^1.0.1"
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.3",
+        "set-immediate-shim": "1.0.1"
       }
     },
     "readline2": {
@@ -4456,8 +4456,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
         "mute-stream": "0.0.5"
       },
       "dependencies": {
@@ -4467,7 +4467,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         }
       }
@@ -4478,7 +4478,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "^1.1.6"
+        "resolve": "1.4.0"
       }
     },
     "redent": {
@@ -4487,8 +4487,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
       },
       "dependencies": {
         "indent-string": {
@@ -4497,7 +4497,7 @@
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         }
       }
@@ -4520,7 +4520,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "^0.1.3"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regexpu-core": {
@@ -4529,9 +4529,9 @@
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "dev": true,
       "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
+        "regenerate": "1.3.3",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
       }
     },
     "registry-auth-token": {
@@ -4540,8 +4540,8 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.2",
+        "safe-buffer": "5.1.1"
       }
     },
     "registry-url": {
@@ -4550,7 +4550,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.2"
       }
     },
     "regjsgen": {
@@ -4565,7 +4565,7 @@
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
       "requires": {
-        "jsesc": "~0.5.0"
+        "jsesc": "0.5.0"
       }
     },
     "release-zalgo": {
@@ -4574,7 +4574,7 @@
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
-        "es6-error": "^4.0.1"
+        "es6-error": "4.0.2"
       }
     },
     "remove-trailing-separator": {
@@ -4601,7 +4601,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "^1.0.0"
+        "is-finite": "1.0.2"
       }
     },
     "require-precompiled": {
@@ -4616,8 +4616,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "^0.1.0",
-        "resolve-from": "^1.0.0"
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
       },
       "dependencies": {
         "resolve-from": {
@@ -4634,7 +4634,7 @@
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "resolve-cwd": {
@@ -4643,7 +4643,7 @@
       "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
       "dev": true,
       "requires": {
-        "resolve-from": "^3.0.0"
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-from": {
@@ -4658,8 +4658,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "2.0.1",
+        "signal-exit": "3.0.2"
       }
     },
     "rimraf": {
@@ -4668,7 +4668,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "run-async": {
@@ -4677,7 +4677,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0"
+        "once": "1.4.0"
       }
     },
     "rx-lite": {
@@ -4703,7 +4703,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.4.1"
       }
     },
     "set-immediate-shim": {
@@ -4718,7 +4718,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -4733,9 +4733,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
+        "glob": "7.1.2",
+        "interpret": "1.0.4",
+        "rechoir": "0.6.2"
       }
     },
     "signal-exit": {
@@ -4756,7 +4756,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "slide": {
@@ -4771,7 +4771,7 @@
       "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "source-map": {
@@ -4786,7 +4786,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "spdx-correct": {
@@ -4795,7 +4795,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "^1.0.2"
+        "spdx-license-ids": "1.2.2"
       }
     },
     "spdx-expression-parse": {
@@ -4828,8 +4828,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string_decoder": {
@@ -4837,7 +4837,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -4846,7 +4846,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4869,7 +4869,7 @@
       "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.1"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-eof": {
@@ -4884,7 +4884,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "^4.0.1"
+        "get-stdin": "4.0.1"
       }
     },
     "strip-json-comments": {
@@ -4899,7 +4899,7 @@
       "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "2.0.0"
       }
     },
     "symbol-observable": {
@@ -4914,12 +4914,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "^4.7.0",
-        "ajv-keywords": "^1.0.0",
-        "chalk": "^1.1.1",
-        "lodash": "^4.0.0",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4934,11 +4934,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "slice-ansi": {
@@ -4953,7 +4953,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -4970,7 +4970,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       }
     },
     "text-table": {
@@ -4997,8 +4997,8 @@
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
       }
     },
     "time-require": {
@@ -5007,10 +5007,10 @@
       "integrity": "sha1-+eEss3D8JgXhFARYK6VO9corLZg=",
       "dev": true,
       "requires": {
-        "chalk": "^0.4.0",
-        "date-time": "^0.1.1",
-        "pretty-ms": "^0.2.1",
-        "text-table": "^0.2.0"
+        "chalk": "0.4.0",
+        "date-time": "0.1.1",
+        "pretty-ms": "0.2.2",
+        "text-table": "0.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5025,9 +5025,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
+            "ansi-styles": "1.0.0",
+            "has-color": "0.1.7",
+            "strip-ansi": "0.1.1"
           }
         },
         "date-time": {
@@ -5048,7 +5048,7 @@
           "integrity": "sha1-2oeaaC/zOjcBEEbxPWJ/Z8c7hPY=",
           "dev": true,
           "requires": {
-            "parse-ms": "^0.1.0"
+            "parse-ms": "0.1.2"
           }
         },
         "strip-ansi": {
@@ -5075,7 +5075,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-fast-properties": {
@@ -5108,13 +5108,18 @@
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
       "dev": true
     },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
@@ -5134,7 +5139,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "unique-temp-dir": {
@@ -5143,8 +5148,8 @@
       "integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1",
-        "os-tmpdir": "^1.0.1",
+        "mkdirp": "0.5.1",
+        "os-tmpdir": "1.0.2",
         "uid2": "0.0.3"
       },
       "dependencies": {
@@ -5171,15 +5176,15 @@
       "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "dev": true,
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.2.2",
+        "chalk": "2.2.0",
+        "configstore": "3.1.1",
+        "import-lazy": "2.1.0",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "url-parse-lax": {
@@ -5187,7 +5192,7 @@
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
       "requires": {
-        "prepend-http": "^1.0.1"
+        "prepend-http": "1.0.4"
       }
     },
     "url-to-options": {
@@ -5201,7 +5206,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "^1.0.0"
+        "os-homedir": "1.0.2"
       }
     },
     "util-deprecate": {
@@ -5215,8 +5220,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "~1.0.0",
-        "spdx-expression-parse": "~1.0.0"
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
       }
     },
     "well-known-symbols": {
@@ -5231,7 +5236,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "widest-line": {
@@ -5240,7 +5245,7 @@
       "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1"
+        "string-width": "1.0.2"
       },
       "dependencies": {
         "is-fullwidth-code-point": {
@@ -5249,7 +5254,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "string-width": {
@@ -5258,9 +5263,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -5269,7 +5274,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -5292,7 +5297,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1"
+        "mkdirp": "0.5.1"
       },
       "dependencies": {
         "mkdirp": {
@@ -5312,9 +5317,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.2"
       }
     },
     "write-json-file": {
@@ -5323,12 +5328,12 @@
       "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
       "dev": true,
       "requires": {
-        "detect-indent": "^5.0.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "pify": "^3.0.0",
-        "sort-keys": "^2.0.0",
-        "write-file-atomic": "^2.0.0"
+        "detect-indent": "5.0.0",
+        "graceful-fs": "4.1.11",
+        "make-dir": "1.0.0",
+        "pify": "3.0.0",
+        "sort-keys": "2.0.0",
+        "write-file-atomic": "2.3.0"
       },
       "dependencies": {
         "detect-indent": {
@@ -5351,8 +5356,8 @@
       "integrity": "sha1-AwqZlMyZk9JbTnWp8aGSNgcpHOk=",
       "dev": true,
       "requires": {
-        "sort-keys": "^2.0.0",
-        "write-json-file": "^2.2.0"
+        "sort-keys": "2.0.0",
+        "write-json-file": "2.3.0"
       }
     },
     "xdg-basedir": {
@@ -5367,31 +5372,31 @@
       "integrity": "sha1-kqQusCpPsUnf6lUYAhkU9arIT/A=",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "debug": "^2.2.0",
-        "deep-assign": "^1.0.0",
-        "eslint": "^3.18.0",
-        "eslint-config-xo": "^0.18.0",
-        "eslint-formatter-pretty": "^1.0.0",
-        "eslint-plugin-ava": "^4.2.0",
-        "eslint-plugin-import": "^2.0.0",
-        "eslint-plugin-no-use-extend-native": "^0.3.2",
-        "eslint-plugin-promise": "^3.4.0",
-        "eslint-plugin-unicorn": "^2.1.0",
-        "get-stdin": "^5.0.0",
-        "globby": "^6.0.0",
-        "has-flag": "^2.0.0",
-        "ignore": "^3.2.6",
-        "lodash.isequal": "^4.4.0",
-        "meow": "^3.4.2",
-        "multimatch": "^2.1.0",
-        "path-exists": "^3.0.0",
-        "pkg-conf": "^2.0.0",
-        "resolve-cwd": "^1.0.0",
-        "resolve-from": "^2.0.0",
-        "slash": "^1.0.0",
-        "update-notifier": "^2.1.0",
-        "xo-init": "^0.5.0"
+        "arrify": "1.0.1",
+        "debug": "2.6.9",
+        "deep-assign": "1.0.0",
+        "eslint": "3.19.0",
+        "eslint-config-xo": "0.18.2",
+        "eslint-formatter-pretty": "1.3.0",
+        "eslint-plugin-ava": "4.2.2",
+        "eslint-plugin-import": "2.8.0",
+        "eslint-plugin-no-use-extend-native": "0.3.12",
+        "eslint-plugin-promise": "3.6.0",
+        "eslint-plugin-unicorn": "2.1.2",
+        "get-stdin": "5.0.1",
+        "globby": "6.1.0",
+        "has-flag": "2.0.0",
+        "ignore": "3.3.5",
+        "lodash.isequal": "4.5.0",
+        "meow": "3.7.0",
+        "multimatch": "2.1.0",
+        "path-exists": "3.0.0",
+        "pkg-conf": "2.0.0",
+        "resolve-cwd": "1.0.0",
+        "resolve-from": "2.0.0",
+        "slash": "1.0.0",
+        "update-notifier": "2.3.0",
+        "xo-init": "0.5.0"
       },
       "dependencies": {
         "debug": {
@@ -5421,7 +5426,7 @@
           "integrity": "sha1-Tq7qQe0EDRcCRX32SkKysH0kb58=",
           "dev": true,
           "requires": {
-            "resolve-from": "^2.0.0"
+            "resolve-from": "2.0.0"
           }
         },
         "resolve-from": {
@@ -5438,13 +5443,13 @@
       "integrity": "sha1-jijex5Z2zF4EL95f2PcQ4mRrDjY=",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "execa": "^0.5.0",
-        "minimist": "^1.1.3",
-        "path-exists": "^3.0.0",
-        "read-pkg-up": "^2.0.0",
-        "the-argv": "^1.0.0",
-        "write-pkg": "^2.0.0"
+        "arrify": "1.0.1",
+        "execa": "0.5.1",
+        "minimist": "1.2.0",
+        "path-exists": "3.0.0",
+        "read-pkg-up": "2.0.0",
+        "the-argv": "1.0.0",
+        "write-pkg": "2.1.0"
       },
       "dependencies": {
         "cross-spawn": {
@@ -5453,8 +5458,8 @@
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.1",
+            "which": "1.3.0"
           }
         },
         "execa": {
@@ -5463,13 +5468,13 @@
           "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
           "dev": true,
           "requires": {
-            "cross-spawn": "^4.0.0",
-            "get-stream": "^2.2.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "4.0.2",
+            "get-stream": "2.3.1",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           }
         },
         "get-stream": {
@@ -5478,8 +5483,8 @@
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
-            "object-assign": "^4.0.1",
-            "pinkie-promise": "^2.0.0"
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
           }
         },
         "minimist": {
@@ -5500,7 +5505,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "sort-keys": {
@@ -5509,7 +5514,7 @@
           "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "^1.0.0"
+            "is-plain-obj": "1.1.0"
           }
         },
         "write-pkg": {
@@ -5518,8 +5523,8 @@
           "integrity": "sha1-NTqkTDnEjCFED1wIzmq9RhQcnAg=",
           "dev": true,
           "requires": {
-            "sort-keys": "^1.1.2",
-            "write-json-file": "^2.0.0"
+            "sort-keys": "1.1.2",
+            "write-json-file": "2.3.0"
           }
         }
       }
@@ -5541,7 +5546,7 @@
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "fd-slicer": "1.0.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "debug": "^4.1.0",
     "extract-zip": "^1.6.7",
     "got": "^7.1.0",
-    "tmp": "0.0.33"
+    "tmp": "0.0.33",
+    "tunnel": "^0.0.6"
   },
   "devDependencies": {
     "ava": "^0.22.0",

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const Url = require('url');
+const urlParser = require('url');
 const got = require('got');
 const tunnel = require('tunnel');
 
@@ -112,10 +112,10 @@ module.exports = {
         const proxy = url.startsWith('https://') ? process.env.npm_config_https_proxy : (process.env.npm_config_proxy || process.env.npm_config_http_proxy);
         if (proxy) {
             console.info('Using http(s) proxy server: ' + proxy);
-            const proxyUrl = new Url(proxy);
+            const proxyUrl = urlParser.parse(proxy);
             const tunnelOptions = {
                 proxy: {
-                    host: proxyUrl.host,
+                    host: proxyUrl.hostname,
                     port: proxyUrl.port
                 }
             };

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const path = require('path');
+const Url = require('url');
 const got = require('got');
+const tunnel = require('tunnel');
 
 const config = require('./config');
 
@@ -97,6 +99,41 @@ module.exports = {
      */
     async getLatestRevisionNumber() {
         const url = this.getOsCdnUrl() + '%2FLAST_CHANGE?alt=media';
-        return (await got(url)).body;
+        return (await got(url, this.getRequestOptions(url))).body;
+    },
+
+    /**
+     * Computes necessary configuration options for use with *got*. For the time being this only considers proxy settings.
+     * @param url the target URL
+     * @returns {Object}
+     */
+    getRequestOptions(url) {
+        const requestOptions = {};
+        const proxy = url.startsWith('https://') ? process.env.npm_config_https_proxy : (process.env.npm_config_proxy || process.env.npm_config_http_proxy);
+        if (proxy) {
+            console.info('Using http(s) proxy server: ' + proxy);
+            const proxyUrl = new Url(proxy);
+            const tunnelOptions = {
+                proxy: {
+                    host: proxyUrl.host,
+                    port: proxyUrl.port
+                }
+            };
+            if (proxyUrl.username && proxyUrl.password) {
+                tunnelOptions.proxy.proxyAuth = `${proxyUrl.username}:${proxyUrl.password}`;
+            }
+            if (url.startsWith('https://')) {
+                if (proxy.startsWith('https://')) {
+                    requestOptions.agent = tunnel.httpsOverHttps(tunnelOptions);
+                } else {
+                    requestOptions.agent = tunnel.httpsOverHttp(tunnelOptions);
+                }
+            } else if (proxy.startsWith('https://')) {
+                requestOptions.agent = tunnel.httpOverHttps(tunnelOptions);
+            } else {
+                requestOptions.agent = tunnel.httpOverHttp(tunnelOptions);
+            }
+        }
+        return requestOptions;
     }
 };


### PR DESCRIPTION
Our usecase requires us to tunnel all of npms connections through a proxy server. This did not work with _node-chromium_. This pull request implements proxy tunneling using the _tunnel_ package and the existing proxy config in npmrc.

Tested on OSX and Windows with HTTPS connections over an HTTP tunnel.