### PR TITLE
Honor HTTP_PROXY, HTTPS_PROXY and NO_PROXY environment variables

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -35,7 +35,10 @@ When downloading the chromium binary **node-chromium** will use the proxy config
 ```
 npm config set proxy http://<username>:<password>@<the.proxy.hostname>:<port>
 npm config set https-proxy http://<username>:<password>@<the.proxy.hostname>:<port
+npm config set no-proxy localhost,127.0.0.1,example.org
 ```
+
+Additionally proxy settings found in the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` will be used if they are not defined in the `.npmrc` file. 
 
 ## Selenium WebDriver Headless (without UI) tests
 It's extremely easy to use **node-chromium** with **selenium-webdriver** to perform e2e tests without spawning browser UI.

--- a/utils.js
+++ b/utils.js
@@ -114,7 +114,7 @@ module.exports = {
         if (proxy) {
             const proxyUrl = urlParser.parse(proxy);
             const noProxy = (process.env.npm_config_no_proxy || process.env.NO_PROXY || '').split(',');
-            if (!noProxy.find(exc => proxyUrl.hostname.endsWith(exc))) {
+            if (noProxy.find(exc => proxyUrl.hostname.endsWith(exc)) !== undefined) {
                 console.info('Using http(s) proxy server: ' + proxy);
                 const tunnelOptions = {
                     proxy: {

--- a/utils.js
+++ b/utils.js
@@ -109,29 +109,33 @@ module.exports = {
      */
     getRequestOptions(url) {
         const requestOptions = {};
-        const proxy = url.startsWith('https://') ? process.env.npm_config_https_proxy : (process.env.npm_config_proxy || process.env.npm_config_http_proxy);
+        const proxy = url.startsWith('https://') ? (process.env.npm_config_https_proxy || process.env.HTTPS_PROXY) :
+            (process.env.npm_config_proxy || process.env.npm_config_http_proxy || process.env.HTTP_PROXY);
         if (proxy) {
-            console.info('Using http(s) proxy server: ' + proxy);
             const proxyUrl = urlParser.parse(proxy);
-            const tunnelOptions = {
-                proxy: {
-                    host: proxyUrl.hostname,
-                    port: proxyUrl.port
+            const noProxy = (process.env.npm_config_no_proxy || process.env.NO_PROXY || '').split(',');
+            if (!noProxy.find(exc => proxyUrl.hostname.endsWith(exc))) {
+                console.info('Using http(s) proxy server: ' + proxy);
+                const tunnelOptions = {
+                    proxy: {
+                        host: proxyUrl.hostname,
+                        port: proxyUrl.port
+                    }
+                };
+                if (proxyUrl.username && proxyUrl.password) {
+                    tunnelOptions.proxy.proxyAuth = `${proxyUrl.username}:${proxyUrl.password}`;
                 }
-            };
-            if (proxyUrl.username && proxyUrl.password) {
-                tunnelOptions.proxy.proxyAuth = `${proxyUrl.username}:${proxyUrl.password}`;
-            }
-            if (url.startsWith('https://')) {
-                if (proxy.startsWith('https://')) {
-                    requestOptions.agent = tunnel.httpsOverHttps(tunnelOptions);
+                if (url.startsWith('https://')) {
+                    if (proxy.startsWith('https://')) {
+                        requestOptions.agent = tunnel.httpsOverHttps(tunnelOptions);
+                    } else {
+                        requestOptions.agent = tunnel.httpsOverHttp(tunnelOptions);
+                    }
+                } else if (proxy.startsWith('https://')) {
+                    requestOptions.agent = tunnel.httpOverHttps(tunnelOptions);
                 } else {
-                    requestOptions.agent = tunnel.httpsOverHttp(tunnelOptions);
+                    requestOptions.agent = tunnel.httpOverHttp(tunnelOptions);
                 }
-            } else if (proxy.startsWith('https://')) {
-                requestOptions.agent = tunnel.httpOverHttps(tunnelOptions);
-            } else {
-                requestOptions.agent = tunnel.httpOverHttp(tunnelOptions);
             }
         }
         return requestOptions;


### PR DESCRIPTION
In accordance to the [npm  documentation](https://docs.npmjs.com/misc/config#https-proxy) _node-chromium_ should ideally also be able to handle proxy settings from environment variables.

Tested on Mac OSX and Windows using different proxy configurations scenarios.