### PR TITLE
Allow specific revisions to be installed

### DIFF
--- a/install.js
+++ b/install.js
@@ -68,7 +68,7 @@ function unzipArchive(archivePath, outputFolder) {
 async function install() {
     try {
         console.info('Step 1. Retrieving Chromium revision number');
-		const revision = process.env.CHROMIUM_REVISION || await utils.getLatestRevisionNumber();
+        const revision = process.env.CHROMIUM_REVISION || await utils.getLatestRevisionNumber();
 
         console.info('Step 2. Downloading Chromium (this might take a while)');
         const tmpPath = await downloadChromiumRevision(revision);

--- a/install.js
+++ b/install.js
@@ -67,8 +67,8 @@ function unzipArchive(archivePath, outputFolder) {
 
 async function install() {
     try {
-        console.info('Step 1. Retrieving Chromium latest revision number');
-        const revision = await utils.getLatestRevisionNumber();
+        console.info('Step 1. Retrieving Chromium revision number');
+		const revision = process.env.CHROMIUM_REVISION || await utils.getLatestRevisionNumber();
 
         console.info('Step 2. Downloading Chromium (this might take a while)');
         const tmpPath = await downloadChromiumRevision(revision);


### PR DESCRIPTION
This is a solution to:
https://github.com/dtolstyi/node-chromium/issues/1

Using environment variables because the NPM team doesn't want to add parameters for `npm i` as they think environment variables suffice. The package will continue working as it is right now unless the environment variable `CHROMIUM_REVISION` is set. In that case it will use whatever number you specify.