### PR TITLE
Allow to specify the revision of Chromium to download

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -40,6 +40,12 @@ npm config set no-proxy localhost,127.0.0.1,example.org
 
 Additionally proxy settings found in the environment variables `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` will be used if they are not defined in the `.npmrc` file. 
 
+### Install a concrete revision
+If you want to specify the revision of Chromium to be installed, just set the environment variable CHROMIUM_REVISION to the number of the revision you want to install, as in:
+```shell script
+export CHROMIUM_REVISION=729994
+```
+
 ## Selenium WebDriver Headless (without UI) tests
 It's extremely easy to use **node-chromium** with **selenium-webdriver** to perform e2e tests without spawning browser UI.
 First, install all dependencies

--- a/install.js
+++ b/install.js
@@ -8,6 +8,7 @@ const debug = require('debug')('node-chromium');
 
 const config = require('./config');
 const utils = require('./utils');
+
 const chromiumRevision = process.env.CHROMIUM_REVISION;
 
 function createTempFile() {

--- a/install.js
+++ b/install.js
@@ -8,6 +8,7 @@ const debug = require('debug')('node-chromium');
 
 const config = require('./config');
 const utils = require('./utils');
+const chromiumRevision = process.env.CHROMIUM_REVISION;
 
 function createTempFile() {
     return new Promise((resolve, reject) => {
@@ -68,9 +69,9 @@ function unzipArchive(archivePath, outputFolder) {
 async function install() {
     try {
         console.info('Step 1. Retrieving Chromium latest revision number');
-        const revision = await utils.getLatestRevisionNumber();
+        const revision = chromiumRevision || await utils.getLatestRevisionNumber();
 
-        console.info('Step 2. Downloading Chromium (this might take a while)');
+        console.info(`Step 2. Downloading Chromium (this might take a while). Revision number: ${revision}`);
         const tmpPath = await downloadChromiumRevision(revision);
 
         console.info('Step 3. Setting up Chromium binaries');


### PR DESCRIPTION
I have added a small modification to install.js that reads the CHROMIUM_REVISION environment variable and tries to download that revision instead of the latest. If the variable hasn't been defined, it will download the latest revision available, as it does now.