### PR TITLE
Allow setting chromium revision from .npmrc

### DIFF
--- a/install.js
+++ b/install.js
@@ -9,7 +9,7 @@ const debug = require('debug')('node-chromium');
 const config = require('./config');
 const utils = require('./utils');
 
-const chromiumRevision = process.env.CHROMIUM_REVISION;
+const chromiumRevision =  process.env.npm_config_chromium_revision || process.env.CHROMIUM_REVISION;
 
 function createTempFile() {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Allow setting chromium revision from `.npmrc` file (https://docs.npmjs.com/files/npmrc):
Copied from: https://github.com/giggio/node-chromedriver/blob/6743dda246ab1e7262e57fb89275a79ec838a5a3/install.js#L18

Closes https://github.com/dtolstyi/node-chromium/issues/26