### PR TITLE
Enable programmatic installation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -143,6 +143,24 @@ export NODE_CHROMIUM_CACHE_DISABLE=true
 # node_chromium_cache_disable=true
 ```
 
+### Skip Automatic Chromium Install
+
+Chromium will ordinarily be installed when you exectute `npm install` however you may wish to skip this step if you are going to defer installation and perform it programatically at a later stage. Below is an example of how to do so.
+
+```bash
+export NODE_CHROMIUM_SKIP_INSTALL=true
+
+# or in .npmrc like so:
+# node_chromium_skip_install=true
+```
+
+Then install it programatically when you need it:
+
+```js
+chromium.install().then(function() {
+    // do stuff...
+});
+```
 ## Contributors
 <table>
   <tr style="background: #ffec86">

--- a/index.js
+++ b/index.js
@@ -15,6 +15,12 @@ function getBinaryPath() {
 }
 
 module.exports = {
-    path: getBinaryPath(),
+    /*
+     * The path property needs to use a getter because the binaries may not be present for any number of reasons.
+     * Using a getter allows this property to update itself as needed and reflect the current state of the filesystem.
+     */
+    get path() {
+        return getBinaryPath();
+    },
     install: require('./install')
 };

--- a/install.js
+++ b/install.js
@@ -142,7 +142,11 @@ async function install() {
 
 if (require.main === module) {
     // Module called directly, not via "require", so execute install...
-    install();
+    if (config.getEnvVar('NODE_CHROMIUM_SKIP_INSTALL').toLowerCase() === 'true') {
+        console.info('Skipping chromium install');
+    } else {
+        install();
+    }
 }
 
 tmp.setGracefulCleanup(); // Ensure temporary files are cleaned up when process exits

--- a/test/test-install.js
+++ b/test/test-install.js
@@ -11,6 +11,7 @@ const testUtils = require('./_utils');
 const utils = require('../utils');
 const config = require('../config');
 const install = require('../install');
+const chromium = require('..');
 
 test.before(t => {
     // Deleting output folder
@@ -36,6 +37,7 @@ test.serial('Canary Test', t => {
 test.serial('Before Install Process', t => {
     const binPath = utils.getOsChromiumBinPath();
     t.false(fs.existsSync(binPath), `Chromium binary is found in: [${binPath}]`);
+    t.falsy(chromium.path, 'chromium.path should not be defined when there is no installation');
 });
 
 test.serial('Chromium Install', async t => {
@@ -43,6 +45,7 @@ test.serial('Chromium Install', async t => {
     const binPath = utils.getOsChromiumBinPath();
     const isExists = fs.existsSync(binPath);
     t.true(isExists, `Chromium binary is not found in: [${binPath}]`);
+    t.true(fs.existsSync(chromium.path), 'chromium.path should be defined after installation');
 });
 
 test.serial('Different OS support', async t => {


### PR DESCRIPTION
Hey man, two things:

1. When programmatically installing chromium the `path` property is not set, it remains undefined. Also if something happens to the installation dir, like it is deleted or something, then the property does not reflect that.

2. It may be easier to include node-chromium as a dependency in some projects if the automatic chromium installation is skipped. It can then be conditionally installed later using the API.
