### PR TITLE
Update getLatestRevisionNumber to match current folder structure

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -102,7 +102,7 @@ module.exports = {
      */
     async getLatestRevisionNumber() {
         const url = this.getOsCdnUrl() + '%2FLAST_CHANGE?alt=media';
-        return (await got(url, this.getRequestOptions(url))).body;
+        return 'refs_heads_main-' + (await got(url, this.getRequestOptions(url))).body;
     },
 
     /**


### PR DESCRIPTION
As of 08/18/21, chromium binaries seem to be stored now in folder prefixed with `refs_head_main-`, followed by the revision number. This PR is a quick and dirty fix for this issue.

It's unclear if this is a storage policy change or a code change on the Chromium side.